### PR TITLE
Fix 404 error that cannot retrieve google-analytics.js

### DIFF
--- a/src/components/head.cljs.hl
+++ b/src/components/head.cljs.hl
@@ -8,7 +8,7 @@
   (link :rel "canonical" :href "http://clojure.tw"))
 
 (defelem google-analytics []
-  (script :src "assets/google-analytics.js"))
+  (script :src "google-analytics.js"))
 
 (defelem generic-head
   [children]


### PR DESCRIPTION
Fix issue #7 